### PR TITLE
fix: desktop auth non closable modal 

### DIFF
--- a/app/src/components/authentication/DesktopSignIn/DesktopSignIn.js
+++ b/app/src/components/authentication/DesktopSignIn/DesktopSignIn.js
@@ -49,7 +49,7 @@ const DesktopSignIn = () => {
           modalName: "authModal",
           newValue: value,
           newProps: {
-            isClosable: false,
+            closable: false,
           },
         })
       );


### PR DESCRIPTION
Linear: https://linear.app/requestly/issue/ENGG-3466/desktop-app-auth-modal-should-not-be-closable